### PR TITLE
Hide stock display and add assistant role

### DIFF
--- a/bot/database/models/main.py
+++ b/bot/database/models/main.py
@@ -12,6 +12,7 @@ class Permission:
     SHOP_MANAGE = 16
     ADMINS_MANAGE = 32
     OWN = 64
+    ASSIGN_PHOTOS = 128
 
 
 class Role(Database.BASE):
@@ -34,11 +35,13 @@ class Role(Database.BASE):
         roles = {
             'USER': [Permission.USE],
             'ADMIN': [Permission.USE, Permission.BROADCAST,
-                      Permission.SETTINGS_MANAGE, Permission.USERS_MANAGE, Permission.SHOP_MANAGE, ],
+                      Permission.SETTINGS_MANAGE, Permission.USERS_MANAGE,
+                      Permission.SHOP_MANAGE, Permission.ASSIGN_PHOTOS],
             'OWNER': [Permission.USE, Permission.BROADCAST,
-                      Permission.SETTINGS_MANAGE, Permission.USERS_MANAGE, Permission.SHOP_MANAGE,
-                      Permission.ADMINS_MANAGE,
-                      Permission.OWN],
+                      Permission.SETTINGS_MANAGE, Permission.USERS_MANAGE,
+                      Permission.SHOP_MANAGE, Permission.ADMINS_MANAGE,
+                      Permission.OWN, Permission.ASSIGN_PHOTOS],
+            'ASSISTANT': [Permission.USE, Permission.ASSIGN_PHOTOS],
         }
         default_role = 'USER'
         for r in roles:

--- a/bot/handlers/admin/assistant_management_states.py
+++ b/bot/handlers/admin/assistant_management_states.py
@@ -1,0 +1,74 @@
+from aiogram import Dispatcher
+from aiogram.types import CallbackQuery, Message, InlineKeyboardMarkup, InlineKeyboardButton
+
+from bot.database.methods import check_role, check_user_by_username, set_role
+from bot.database.models import Permission
+from bot.keyboards import back
+from bot.misc import TgConfig
+from bot.handlers.other import get_bot_user_ids
+
+ASSISTANT_ROLE_ID = 4
+
+async def assistant_management_callback(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    role = check_role(user_id)
+    if not (role & Permission.OWN):
+        await call.answer('Insufficient rights')
+        return
+    TgConfig.STATE[user_id] = None
+    markup = InlineKeyboardMarkup()
+    markup.add(InlineKeyboardButton('➕ Add assistant', callback_data='assistant_add'))
+    markup.add(InlineKeyboardButton('➖ Remove assistant', callback_data='assistant_remove'))
+    markup.add(InlineKeyboardButton('🔙 Back', callback_data='console'))
+    await bot.edit_message_text('Choose action:', chat_id=call.message.chat.id,
+                                message_id=call.message.message_id, reply_markup=markup)
+
+async def assistant_add_callback(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[user_id] = 'assistant_add_username'
+    TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
+    await bot.edit_message_text('Send username of assistant:', chat_id=call.message.chat.id,
+                                message_id=call.message.message_id, reply_markup=back('assistant_management'))
+
+async def assistant_remove_callback(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    TgConfig.STATE[user_id] = 'assistant_remove_username'
+    TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
+    await bot.edit_message_text('Send username to remove:', chat_id=call.message.chat.id,
+                                message_id=call.message.message_id, reply_markup=back('assistant_management'))
+
+async def process_assistant_username(message: Message):
+    bot, user_id = await get_bot_user_ids(message)
+    state = TgConfig.STATE.get(user_id)
+    if state not in {'assistant_add_username', 'assistant_remove_username'}:
+        return
+    username = message.text.lstrip('@')
+    message_id = TgConfig.STATE.get(f'{user_id}_message_id')
+    TgConfig.STATE[user_id] = None
+    await bot.delete_message(chat_id=message.chat.id, message_id=message.message_id)
+    user = check_user_by_username(username)
+    if not user:
+        await bot.edit_message_text('❌ User not found', chat_id=message.chat.id,
+                                    message_id=message_id, reply_markup=back('assistant_management'))
+        return
+    if state == 'assistant_add_username':
+        set_role(user.telegram_id, ASSISTANT_ROLE_ID)
+        await bot.edit_message_text('✅ Assistant assigned', chat_id=message.chat.id,
+                                    message_id=message_id, reply_markup=back('assistant_management'))
+    else:
+        set_role(user.telegram_id, 1)
+        await bot.edit_message_text('✅ Assistant removed', chat_id=message.chat.id,
+                                    message_id=message_id, reply_markup=back('assistant_management'))
+
+
+def register_assistant_management(dp: Dispatcher) -> None:
+    dp.register_callback_query_handler(assistant_management_callback,
+                                       lambda c: c.data == 'assistant_management')
+    dp.register_callback_query_handler(assistant_add_callback,
+                                       lambda c: c.data == 'assistant_add')
+    dp.register_callback_query_handler(assistant_remove_callback,
+                                       lambda c: c.data == 'assistant_remove')
+    dp.register_message_handler(process_assistant_username,
+                                lambda m: TgConfig.STATE.get(m.from_user.id) in {
+                                    'assistant_add_username', 'assistant_remove_username'
+                                })

--- a/bot/handlers/admin/broadcast.py
+++ b/bot/handlers/admin/broadcast.py
@@ -16,7 +16,7 @@ async def send_message_callback_handler(call: CallbackQuery):
     TgConfig.STATE[user_id] = 'waiting_for_message'
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     role = check_role(user_id)
-    if role >= Permission.BROADCAST:
+    if role & Permission.BROADCAST:
         await bot.edit_message_text(chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
                                     text='Send the message for broadcast:',

--- a/bot/handlers/admin/main.py
+++ b/bot/handlers/admin/main.py
@@ -3,11 +3,13 @@ from aiogram.types import CallbackQuery
 
 from bot.keyboards import console
 from bot.database.methods import check_role
+from bot.database.models import Permission
 from bot.misc import TgConfig
 
 from bot.handlers.admin.broadcast import register_mailing
 from bot.handlers.admin.shop_management_states import register_shop_management
 from bot.handlers.admin.user_management_states import register_user_management
+from bot.handlers.admin.assistant_management_states import register_assistant_management
 from bot.handlers.other import get_bot_user_ids
 
 
@@ -15,11 +17,13 @@ async def console_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     TgConfig.STATE[user_id] = None
     role = check_role(user_id)
-    if role > 1:
+    if role != Permission.USE:
         await bot.edit_message_text('⛩️ Administrator menu',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
-                                    reply_markup=console())
+                                    reply_markup=console(role))
+        return
+    await call.answer('Insufficient rights')
 
 
 def register_admin_handlers(dp: Dispatcher) -> None:
@@ -29,3 +33,4 @@ def register_admin_handlers(dp: Dispatcher) -> None:
     register_mailing(dp)
     register_shop_management(dp)
     register_user_management(dp)
+    register_assistant_management(dp)

--- a/bot/handlers/admin/shop_management_states.py
+++ b/bot/handlers/admin/shop_management_states.py
@@ -25,6 +25,7 @@ from bot.database.methods import (
     get_all_items,
     get_all_subcategories,
     get_category_parent,
+    get_item_info,
     get_user_count,
     select_admins,
     select_all_operations,
@@ -56,14 +57,14 @@ from bot.keyboards import (shop_management, goods_management, categories_managem
                            question_buttons, promo_codes_management, promo_expiry_keyboard, promo_codes_list,
                            promo_manage_actions)
 from bot.logger_mesh import logger
-from bot.misc import TgConfig
+from bot.misc import TgConfig, EnvKeys
 
 
 async def shop_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     TgConfig.STATE[user_id] = None
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         await bot.edit_message_text('⛩️ Shop management menu',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
@@ -77,7 +78,7 @@ async def logs_callback_handler(call: CallbackQuery):
     TgConfig.STATE[user_id] = None
     role = check_role(user_id)
     file_path = 'bot.log'
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         if os.path.exists(file_path) and os.path.getsize(file_path) > 0:
             with open(file_path, 'rb') as document:
                 await bot.send_document(chat_id=call.message.chat.id,
@@ -93,7 +94,7 @@ async def goods_management_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     TgConfig.STATE[user_id] = None
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         await bot.edit_message_text('🛒 Prekių valdymo meniu',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
@@ -106,7 +107,7 @@ async def promo_management_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     TgConfig.STATE[user_id] = None
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         await bot.edit_message_text('🏷 Promo codes menu',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
@@ -375,7 +376,7 @@ async def promo_manage_delete_handler(call: CallbackQuery):
 async def assign_photos_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     role = check_role(user_id)
-    if role < Permission.SHOP_MANAGE:
+    if not (role & Permission.SHOP_MANAGE or role & Permission.ASSIGN_PHOTOS):
         await call.answer('Insufficient rights')
         return
     TgConfig.STATE[user_id] = None
@@ -392,6 +393,10 @@ async def assign_photos_callback_handler(call: CallbackQuery):
 
 async def assign_photo_category_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
+    role = check_role(user_id)
+    if not (role & Permission.SHOP_MANAGE or role & Permission.ASSIGN_PHOTOS):
+        await call.answer('Insufficient rights')
+        return
     category = call.data[len('assign_photo_cat_'):]
     subcats = get_all_subcategories(category)
     markup = InlineKeyboardMarkup()
@@ -409,6 +414,10 @@ async def assign_photo_category_handler(call: CallbackQuery):
 
 async def assign_photo_subcategory_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
+    role = check_role(user_id)
+    if not (role & Permission.SHOP_MANAGE or role & Permission.ASSIGN_PHOTOS):
+        await call.answer('Insufficient rights')
+        return
     sub = call.data[len('assign_photo_sub_'):]
     items = get_all_item_names(sub)
     markup = InlineKeyboardMarkup()
@@ -423,6 +432,10 @@ async def assign_photo_subcategory_handler(call: CallbackQuery):
 
 async def assign_photo_item_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
+    role = check_role(user_id)
+    if not (role & Permission.SHOP_MANAGE or role & Permission.ASSIGN_PHOTOS):
+        await call.answer('Insufficient rights')
+        return
     item = call.data[len('assign_photo_item_'):]
     TgConfig.STATE[user_id] = 'assign_photo_wait_media'
     TgConfig.STATE[f'{user_id}_item'] = item
@@ -435,6 +448,9 @@ async def assign_photo_item_handler(call: CallbackQuery):
 
 async def assign_photo_receive_media(message: Message):
     bot, user_id = await get_bot_user_ids(message)
+    role = check_role(user_id)
+    if not (role & Permission.SHOP_MANAGE or role & Permission.ASSIGN_PHOTOS):
+        return
     item = TgConfig.STATE.get(f'{user_id}_item')
     message_id = TgConfig.STATE.get(f'{user_id}_message_id')
     if not item:
@@ -465,6 +481,9 @@ async def assign_photo_receive_media(message: Message):
 
 async def assign_photo_receive_desc(message: Message):
     bot, user_id = await get_bot_user_ids(message)
+    role = check_role(user_id)
+    if not (role & Permission.SHOP_MANAGE or role & Permission.ASSIGN_PHOTOS):
+        return
     item = TgConfig.STATE.get(f'{user_id}_item')
     stock_path = TgConfig.STATE.get(f'{user_id}_stock_path')
     message_id = TgConfig.STATE.get(f'{user_id}_message_id')
@@ -485,12 +504,60 @@ async def assign_photo_receive_desc(message: Message):
                                 message_id=message_id,
                                 reply_markup=goods_management())
 
+    owner_id = int(EnvKeys.OWNER_ID) if EnvKeys.OWNER_ID else None
+    if owner_id:
+        username = f'@{message.from_user.username}' if message.from_user.username else message.from_user.full_name
+        info = get_item_info(item)
+        category = info['category_name']
+        parent = get_category_parent(category)
+        if parent:
+            category_name = parent
+            subcategory = category
+        else:
+            category_name = category
+            subcategory = '-'
+        now = datetime.datetime.utcnow() + datetime.timedelta(hours=3)
+        info_id = f'{user_id}_{int(now.timestamp())}'
+        TgConfig.STATE[f'photo_info_{info_id}'] = {
+            'username': username,
+            'time': now.strftime("%Y-%m-%d %H:%M:%S"),
+            'product': display_name(item),
+            'category': category_name,
+            'subcategory': subcategory,
+            'description': message.text,
+            'file': stock_path,
+        }
+        markup = InlineKeyboardMarkup().add(InlineKeyboardButton('Yes', callback_data=f'photo_info_{info_id}'))
+        await bot.send_message(owner_id,
+                               f'{username}, uploaded a photo to a ({display_name(item)}) in ({category_name}), ({subcategory}).',
+                               reply_markup=markup)
+
+
+async def photo_info_callback_handler(call: CallbackQuery):
+    bot, user_id = await get_bot_user_ids(call)
+    data_id = call.data[len('photo_info_'):]
+    info = TgConfig.STATE.pop(f'photo_info_{data_id}', None)
+    if not info:
+        await call.answer('No data')
+        return
+    text = (
+        f"{info['username']}\n"
+        f"{info['time']}\n"
+        f"Product: {info['product']}\n"
+        f"Category: {info['category']} | {info['subcategory']}\n"
+        f"Description: {info['description']}\n"
+        f"File: {info['file']}"
+    )
+    await bot.edit_message_text(text,
+                                chat_id=call.message.chat.id,
+                                message_id=call.message.message_id)
+
 
 async def categories_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     TgConfig.STATE[user_id] = None
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         await bot.edit_message_text('🧾 Kategorijų valdymo meniu',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
@@ -504,7 +571,7 @@ async def add_category_callback_handler(call: CallbackQuery):
     TgConfig.STATE[user_id] = 'add_category'
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         await bot.edit_message_text('Enter category name',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
@@ -517,7 +584,7 @@ async def add_subcategory_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         categories = get_all_category_names()
         markup = InlineKeyboardMarkup()
         for cat in categories:
@@ -554,7 +621,7 @@ async def statistics_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     TgConfig.STATE[user_id] = None
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         today = datetime.datetime.now().strftime("%Y-%m-%d")
         await bot.edit_message_text('Shop statistics:\n'
                                     '➖➖➖➖➖➖➖➖➖➖➖➖➖\n'
@@ -634,7 +701,7 @@ async def delete_category_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     TgConfig.STATE[user_id] = None
     role = check_role(user_id)
-    if role < Permission.SHOP_MANAGE:
+    if not (role & Permission.SHOP_MANAGE):
         await call.answer('Insufficient rights')
         return
     categories = get_all_category_names()
@@ -682,7 +749,7 @@ async def update_category_callback_handler(call: CallbackQuery):
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     TgConfig.STATE[user_id] = 'check_category'
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         await bot.edit_message_text('Enter category name to update:',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
@@ -732,7 +799,7 @@ async def goods_settings_menu_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     TgConfig.STATE[user_id] = None
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         await bot.edit_message_text('🛒 Pasirinkite veiksmą šiai prekei',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
@@ -746,7 +813,7 @@ async def add_item_callback_handler(call: CallbackQuery):
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     TgConfig.STATE[user_id] = 'create_item_name'
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         await bot.edit_message_text('🏷️ Įveskite prekės pavadinimą',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
@@ -896,7 +963,7 @@ async def update_item_amount_callback_handler(call: CallbackQuery):
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     TgConfig.STATE[user_id] = 'update_amount_of_item'
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         await bot.edit_message_text('🏷️ Įveskite prekės pavadinimą',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
@@ -956,11 +1023,11 @@ async def updating_item_amount(message: Message):
     group_id = TgConfig.GROUP_ID if TgConfig.GROUP_ID != -988765433 else None
     if group_id:
         try:
-            await bot.send_message(chat_id=group_id,
-                                   text=f'🎁 Upload\n'
-                                        f'🏷️ Item: <b>{item_name}</b>'
-                                        f'\n📦 Quantity: <b>{len(values_list)}</b>',
-                                   parse_mode='HTML')
+            await bot.send_message(
+                chat_id=group_id,
+                text=f'🎁 Upload\n🏷️ Item: <b>{item_name}</b>',
+                parse_mode='HTML'
+            )
         except ChatNotFound:
             pass
     await bot.edit_message_text(chat_id=message.chat.id,
@@ -977,7 +1044,7 @@ async def update_item_callback_handler(call: CallbackQuery):
     TgConfig.STATE[user_id] = 'check_item_name'
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         await bot.edit_message_text('🏷️ Įveskite prekės pavadinimą',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
@@ -1142,7 +1209,7 @@ async def delete_item_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     TgConfig.STATE[user_id] = None
     role = check_role(user_id)
-    if role < Permission.SHOP_MANAGE:
+    if not (role & Permission.SHOP_MANAGE):
         await call.answer('Insufficient rights')
         return
     categories = get_all_category_names()
@@ -1192,7 +1259,7 @@ async def show_bought_item_callback_handler(call: CallbackQuery):
     TgConfig.STATE[user_id] = 'show_item'
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     role = check_role(user_id)
-    if role >= Permission.SHOP_MANAGE:
+    if role & Permission.SHOP_MANAGE:
         await bot.edit_message_text(
             '🔍 Enter the unique ID of the purchased item',
             chat_id=call.message.chat.id,
@@ -1259,6 +1326,8 @@ def register_shop_management(dp: Dispatcher) -> None:
                                        lambda c: c.data.startswith('assign_photo_sub_'))
     dp.register_callback_query_handler(assign_photo_item_handler,
                                        lambda c: c.data.startswith('assign_photo_item_'))
+    dp.register_callback_query_handler(photo_info_callback_handler,
+                                       lambda c: c.data.startswith('photo_info_'))
     dp.register_callback_query_handler(shop_callback_handler,
                                        lambda c: c.data == 'shop_management')
     dp.register_callback_query_handler(logs_callback_handler,

--- a/bot/handlers/admin/user_management_states.py
+++ b/bot/handlers/admin/user_management_states.py
@@ -18,7 +18,7 @@ async def user_callback_handler(call: CallbackQuery):
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     TgConfig.STATE[user_id] = 'user_username_for_check'
     role = check_role(user_id)
-    if role >= Permission.USERS_MANAGE:
+    if role & Permission.USERS_MANAGE:
         await bot.edit_message_text('👤 Enter the user username to view or edit their data',
                                     chat_id=call.message.chat.id,
                                     message_id=call.message.message_id,
@@ -92,7 +92,7 @@ async def user_items_callback_handler(call: CallbackQuery):
     bot, user_id = await get_bot_user_ids(call)
     user_data = call.data[11:]
     role = check_role(user_id)
-    if role >= Permission.ADMINS_MANAGE:
+    if role & Permission.ADMINS_MANAGE:
         TgConfig.STATE[f'{user_id}_back'] = f'user-items_{user_data}'
         bought_goods = select_bought_items(user_data)
         goods = bought_items_list(user_id)
@@ -115,7 +115,7 @@ async def process_admin_for_purpose(call: CallbackQuery):
     user_data = call.data[10:]
     user_info = await bot.get_chat(user_data)
     role = check_role(user_id)
-    if role >= Permission.ADMINS_MANAGE:
+    if role & Permission.ADMINS_MANAGE:
         set_role(user_data, 2)
         await bot.edit_message_text(
             chat_id=call.message.chat.id,
@@ -144,7 +144,7 @@ async def process_admin_for_remove(call: CallbackQuery):
     user_data = call.data[13:]
     user_info = await bot.get_chat(user_data)
     role = check_role(user_id)
-    if role >= Permission.ADMINS_MANAGE:
+    if role & Permission.ADMINS_MANAGE:
         set_role(user_data, 1)
         await bot.edit_message_text(
             chat_id=call.message.chat.id,
@@ -174,7 +174,7 @@ async def replenish_user_balance_callback_handler(call: CallbackQuery):
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
     TgConfig.STATE[user_id] = 'process_replenish_user_balance'
     role = check_role(user_id)
-    if role >= Permission.USERS_MANAGE:
+    if role & Permission.USERS_MANAGE:
         await bot.edit_message_text(
             chat_id=call.message.chat.id,
             message_id=call.message.message_id,

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -63,8 +63,7 @@ def build_subcategory_description(parent: str, lang: str) -> str:
         goods = get_all_items(sub)
         for item in goods:
             info = get_item_info(item)
-            amount = select_item_values_amount(item) if not check_value(item) else '∞'
-            lines.append(f"    • {display_name(item)} ({info['price']:.2f}€) - {amount}")
+            lines.append(f"    • {display_name(item)} ({info['price']:.2f}€)")
         lines.append("")
     lines.append(t(lang, 'choose_subcategory'))
     return "\n".join(lines)
@@ -544,16 +543,12 @@ async def item_info_callback_handler(call: CallbackQuery):
     TgConfig.STATE[user_id] = None
     item_info_list = get_item_info(item_name)
     category = item_info_list['category_name']
-    quantity = 'Quantity - unlimited'
-    if not check_value(item_name):
-        quantity = f'Quantity - {select_item_values_amount(item_name)}pcs.'
     lang = get_user_language(user_id) or 'en'
     markup = item_info(item_name, category, lang)
     await bot.edit_message_text(
         f'🏪 Item {display_name(item_name)}\n'
         f'Description: {item_info_list["description"]}\n'
-        f'Price - {item_info_list["price"]}€\n'
-        f'{quantity}',
+        f'Price - {item_info_list["price"]}€',
         chat_id=call.message.chat.id,
         message_id=call.message.message_id,
         reply_markup=markup)

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -1,4 +1,5 @@
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from bot.database.models import Permission
 
 from bot.localization import t
 from bot.database.methods import get_category_parent
@@ -126,17 +127,23 @@ def rules() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
 
-def console() -> InlineKeyboardMarkup:
+def console(role: int) -> InlineKeyboardMarkup:
+    assistant_role = Permission.USE | Permission.ASSIGN_PHOTOS
+    if role == assistant_role:
+        inline_keyboard = [
+            [InlineKeyboardButton('🖼 Assign photos', callback_data='assign_photos')],
+            [InlineKeyboardButton('🔙 Back to menu', callback_data='back_to_menu')]
+        ]
+        return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
     inline_keyboard = [
-        [InlineKeyboardButton('🏪 Parduotuvės valdymas', callback_data='shop_management')
-         ],
-        [InlineKeyboardButton('👥 Vartotojų valdymas', callback_data='user_management')
-         ],
-        [InlineKeyboardButton('📢 Pranešimų siuntimas', callback_data='send_message')
-         ],
-        [InlineKeyboardButton('🔙 Back to menu', callback_data='back_to_menu')
-         ]
+        [InlineKeyboardButton('🏪 Parduotuvės valdymas', callback_data='shop_management')],
+        [InlineKeyboardButton('👥 Vartotojų valdymas', callback_data='user_management')],
+        [InlineKeyboardButton('📢 Pranešimų siuntimas', callback_data='send_message')],
     ]
+    if role & Permission.OWN:
+        inline_keyboard.insert(0, [InlineKeyboardButton('🛠 Assign assistants', callback_data='assistant_management')])
+    inline_keyboard.append([InlineKeyboardButton('🔙 Back to menu', callback_data='back_to_menu')])
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
 def confirm_purchase_menu(item_name: str, lang: str) -> InlineKeyboardMarkup:


### PR DESCRIPTION
## Summary
- remove product stock counts from user views
- introduce assistant role with limited photo assignment privileges
- allow owners to manage assistants and receive notifications when photos are uploaded

## Testing
- `python -m py_compile bot/handlers/user/main.py bot/handlers/admin/shop_management_states.py bot/database/models/main.py bot/handlers/admin/broadcast.py bot/handlers/admin/user_management_states.py bot/handlers/admin/main.py bot/keyboards/inline.py bot/handlers/admin/assistant_management_states.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4c09714b88332a61a91a72bd1be52